### PR TITLE
Restore usage info (FREEPBX-12690)

### DIFF
--- a/page.miscdests.php
+++ b/page.miscdests.php
@@ -17,7 +17,7 @@ switch ($view) {
 			$usage_list = framework_display_destination_usage(miscdests_getdest($request['extdisplay']));
 			if(!empty($usage_list)){
 				$usagehtml = <<< HTML
-<div class="panel panel-default">
+<div class="panel panel-default fpbx-usageinfo">
 	<div class="panel-heading">
 		$usage_list[text]
 	</div>

--- a/page.miscdests.php
+++ b/page.miscdests.php
@@ -9,10 +9,25 @@ $header = _("Misc Destinations");
 $helptext = _("Misc Destinations are for adding destinations that can be used by other FreePBX modules, generally used to route incoming calls. If you want to create feature codes that can be dialed by internal users and go to various destinations, please see the <strong>Misc Applications</strong> module.").' '._('If you need access to a Feature Code, such as *98 to dial voicemail or a Time Condition toggle, these destinations are now provided as Feature Code Admin destinations. For upgrade compatibility, if you previously had configured such a destination, it will still work but the Feature Code short cuts select list is not longer provided.<br/><br/>');
 $request = $_REQUEST;
 $view = isset($_REQUEST['view'])?$_REQUEST['view']:'';
+$usagehtml = '';
 switch ($view) {
 	case 'form':
 		if($request['extdisplay']){
 			$heading = _("Edit Misc Destination");
+			$usage_list = framework_display_destination_usage(miscdests_getdest($request['extdisplay']));
+			if(!empty($usage_list)){
+				$usagehtml = <<< HTML
+<div class="panel panel-default">
+	<div class="panel-heading">
+		$usage_list[text]
+	</div>
+	<div class="panel-body">
+		$usage_list[tooltip]
+	</div>
+</div>
+
+HTML;
+			}
 		}else{
 			$heading = _("Add Misc Destination");
 		}
@@ -26,7 +41,8 @@ switch ($view) {
 ?>
 
 <div class="container-fluid">
-	<h1><?php $heading?></h1>
+	<h1><?php echo $heading?></h1>
+	<?php echo $usagehtml?>
 	<div class="well well-info">
 		<?php echo $helptext?>
 	</div>

--- a/views/form.php
+++ b/views/form.php
@@ -2,28 +2,13 @@
 //	License for all code of this FreePBX module can be found in the license file inside the module directory
 //	Copyright 2015 Sangoma Technologies.
 extract($request, EXTR_SKIP);
-$helptext = '';
 if($extdisplay){
 	$thisMiscDest = $md->get($extdisplay);
 	$thisMiscDest = $thisMiscDest[0];
 	$description = $thisMiscDest['description'] ? $thisMiscDest['description']:'';
 	$destdial = $thisMiscDest['destdial'] ? $thisMiscDest['destdial']:'';
-	$usage_list = framework_display_destination_usage(miscdests_getdest($extdisplay));
-	if(!empty($usage_list)){
-		$objects = explode("\n", $usage_list['tooltip']);
-		$helptext = '<div class="alert alert-info" role="alert">';
-		$helptext .= '<i class="glyphicon glyphicon-info-sign fpbx-help-icon" data-for="inuse"></i>&nbsp;' . $usage_list['text'] . '<br/>';
-		$helptext .= '<ul class="list-group">';
-		$objects = is_array($objects)?$objects:array();
-		foreach($objects as $o){
-			$helptext .= '<li class="list-group-item" id="iteminuse">' . $o . '</li>';
-		}
-		$helptext .= '</ul>';
-		$helptext .= '</div>';
-	}
 }
 ?>
-<?php echo $helptext ?>
 <form autocomplete="off" class="fpbx-submit" name="editMD" action="config.php?display=miscdests" method="post" data-fpbx-delete="config.php?display=miscdests&amp;extdisplay=<?php echo $extdisplay ?>&amp;action=delete" role="form">
 	<input type="hidden" name="display" value="miscdests">
 	<input type="hidden" name="action" value="<?php echo ($extdisplay ? 'edit' : 'add') ?>">

--- a/views/grid.php
+++ b/views/grid.php
@@ -5,7 +5,7 @@
  $dataurl = "ajax.php?module=miscdests&command=getJSON&jdata=grid";
 ?>
 <div id="toolbar-all">
-	<a href="config.php?display=miscdests&view=form" class="btn btn-default"><i class="fa fa-plus"></i>&nbsp; <?php echo _("Add Misc Destination") ?></a>
+	<a href="config.php?display=miscdests&amp;view=form" class="btn btn-default"><i class="fa fa-plus"></i>&nbsp; <?php echo _("Add Misc Destination") ?></a>
 </div>
 <table id="miscdestgrid" data-toolbar="#toolbar-all" data-maintain-selected="true" data-url="<?php echo $dataurl?>" data-show-columns="true" data-show-toggle="true" data-toggle="table" data-pagination="true" data-search="true" class="table table-striped">
 	<thead>
@@ -17,7 +17,7 @@
 <script>
 
 function linkFormatter(value, row, index){
-    var html = '<a href="?display=miscdests&view=form&extdisplay='+value+'"><i class="fa fa-pencil"></i></a>';
+    var html = '<a href="?display=miscdests&view=form&extdisplay='+value+'"><i class="fa fa-edit"></i></a>';
     html += '&nbsp;<a href="?display=miscdests&action=delete&extdisplay='+value+'" class="delAction"><i class="fa fa-trash"></i></a>';
     return html;
 }


### PR DESCRIPTION
This module did have usage info, which I've removed to make consistent with other modules. Not sure about how this looks with the big box of help text, but I won't worry about it too much, as most modules don't have it. Screenshot: 
<img width="1159" alt="screenshot 2017-04-28 09 46 12" src="https://cloud.githubusercontent.com/assets/1329102/25538438/906d79d6-2bf7-11e7-8651-bce88bed51af.png">
