### PR TITLE
Update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ This is a module for [FreePBX©](http://www.freepbx.org/ "FreePBX Home Page"). [
 [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") is a completely modular GUI for Asterisk written in PHP and Javascript. Meaning you can easily write any module you can think of and distribute it free of cost to your clients so that they can take advantage of beneficial features in [Asterisk](http://www.asterisk.org/ "Asterisk Home Page")
 
 ### Setting up a FreePBX system
-[See our WIKI](http://wiki.freepbx.org/display/FOP/Install+FreePBX)
+[See our WIKI](http://sangomakb.atlassian.net/wiki/spaces/FP/pages/9732130/Install+FreePBX)
 ### License
 [This modules code is licensed as GPLv3+](https://www.gnu.org/licenses/gpl-3.0.txt)
 ### Contributing
-To contribute code or modules back into the [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") ecosystem you must fully read our Code License Agreement. We are not able to look at or accept patches or code of any kind until this document is filled out. Please take a look at [http://wiki.freepbx.org/display/DC/Code+License+Agreement](http://wiki.freepbx.org/display/DC/Code+License+Agreement) for more information
+To contribute code or modules back into the [FreePBX](http://www.freepbx.org/ "FreePBX Home Page") ecosystem you must fully read our Code License Agreement. We are not able to look at or accept patches or code of any kind until this document is filled out. Please take a look at [http://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682663/Contributor+License+Agreement](http://sangomakb.atlassian.net/wiki/spaces/FP/pages/10682663/Contributor+License+Agreement) for more information
 ### Issues
-Please file bug reports at http://issues.freepbx.org
+Please file bug reports at http://github.com/FreePBX/issue-tracker/issues

--- a/i18n/ru_RU/LC_MESSAGES/miscdests.po
+++ b/i18n/ru_RU/LC_MESSAGES/miscdests.po
@@ -106,7 +106,7 @@ msgstr "Дополнительное направление: %s"
 
 #: miscdests.i18n.php:4 miscdests.i18n.php:10 page.miscdests.php:8
 msgid "Misc Destinations"
-msgstr "Дополнительные назначения"
+msgstr "Дополнительные направления"
 
 #: page.miscdests.php:9
 msgid ""

--- a/module.xml
+++ b/module.xml
@@ -8,7 +8,7 @@
 	<licenselink>https://www.gnu.org/licenses/gpl-3.0.txt</licenselink>
 	<category>Applications</category>
 	<description>Allows creating destinations that dial any local number (extensions, feature codes, outside phone numbers) that can be used by other modules (eg, IVR, time conditions) as a call destination.</description>
-  	<more-info>https://wiki.freepbx.org/display/FPG/Misc+Destinations</more-info>
+  	<more-info>https://sangomakb.atlassian.net/wiki/spaces/PG/pages/24379484/PBX+GUI+-+Misc+Destinations</more-info>
 	<changelog>
 		*17.0.1.1* 17.0.1.1
 		*17.0.1* 17.0


### PR DESCRIPTION
This PR updates the links to the old wiki (wiki.freepbx.org) to the new location (sangomakb.atlassian.net) and updates the settings 'more-info' in the module.xml file

Bugfix FreePBX/issue-tracker#700